### PR TITLE
Apply [[nodiscard]] attributes to functions

### DIFF
--- a/include/kson/Audio/AudioEffect.hpp
+++ b/include/kson/Audio/AudioEffect.hpp
@@ -22,8 +22,10 @@ namespace kson
 		PeakingFilter,
 	};
 
+	[[nodiscard]]
 	AudioEffectType StrToAudioEffectType(std::string_view str);
 
+	[[nodiscard]]
 	std::string_view AudioEffectTypeToStr(AudioEffectType type);
 
 	using AudioEffectParams = Dict<std::string>;
@@ -43,11 +45,14 @@ namespace kson
 		Dict<FXLane<AudioEffectParams>> longEvent;
 
 		// Note: This is inefficient, so be careful when using it
+		[[nodiscard]]
 		bool defContains(std::string_view name) const;
 
 		// Note: This is inefficient, so be careful when using it
+		[[nodiscard]]
 		const AudioEffectDef& defByName(std::string_view name) const;
 
+		[[nodiscard]]
 		Dict<AudioEffectDef> defAsDict() const;
 	};
 
@@ -66,12 +71,15 @@ namespace kson
 
 		// Note: If you call this function frequently, it's recommended to first call defAsDict to get the dictionary and use it,
 		//       as this function uses linear search.
+		[[nodiscard]]
 		bool defContains(std::string_view name) const;
 
 		// Note: If you call this function frequently, it's recommended to first call defAsDict to get the dictionary and use it,
 		//       as this function uses linear search.
+		[[nodiscard]]
 		const AudioEffectDef& defByName(std::string_view name) const;
 
+		[[nodiscard]]
 		Dict<AudioEffectDef> defAsDict() const;
 	};
 

--- a/include/kson/Audio/BGMInfo.hpp
+++ b/include/kson/Audio/BGMInfo.hpp
@@ -17,8 +17,10 @@ namespace kson
 		std::string filenameP; // "xxx_p.ogg", UTF-8 guaranteed
 		std::string filenameFP; // "xxx_fp.ogg", UTF-8 guaranteed
 
+		[[nodiscard]]
 		bool empty() const;
 
+		[[nodiscard]]
 		std::vector<std::string> toStrArray() const;
 	};
 

--- a/include/kson/Camera/Tilt.hpp
+++ b/include/kson/Camera/Tilt.hpp
@@ -72,8 +72,10 @@ namespace kson
 	using TiltValue = std::variant<AutoTiltType, TiltGraphPoint>;
 
 	// Get scale value from AutoTiltType
+	[[nodiscard]]
 	double GetAutoTiltScale(AutoTiltType type);
 
 	// Check if AutoTiltType is a keep type
+	[[nodiscard]]
 	bool IsKeepAutoTiltType(AutoTiltType type);
 }

--- a/include/kson/Common/Common.hpp
+++ b/include/kson/Common/Common.hpp
@@ -100,6 +100,7 @@ namespace kson
 		}
 
 		// Returns true if this represents a linear interpolation (no curve)
+		[[nodiscard]]
 		bool isLinear() const
 		{
 			return a == b;
@@ -160,6 +161,7 @@ namespace kson
 	}
 
 	template <typename T, typename U>
+	[[nodiscard]]
 	U ValueAtOrDefault(const std::map<T, U>& map, T key, const U& defaultValue)
 	{
 		const auto itr = ValueItrAt(map, key);
@@ -171,6 +173,7 @@ namespace kson
 	}
 
 	template <typename T>
+	[[nodiscard]]
 	std::size_t CountInRange(const ByPulse<T>& map, Pulse start, Pulse end)
 	{
 		static_assert(std::is_signed_v<Pulse>);
@@ -186,6 +189,7 @@ namespace kson
 	}
 
 	template <typename T>
+	[[nodiscard]]
 	auto FirstInRange(const ByPulse<T>& map, Pulse start, Pulse end)
 	{
 		static_assert(std::is_signed_v<Pulse>);
@@ -199,6 +203,7 @@ namespace kson
 		return itr;
 	}
 
+	[[nodiscard]]
 	inline double RemoveFloatingPointError(double value)
 	{
 		// Round the value to eight decimal places (e.g. "0.700000004" -> "0.7")
@@ -216,6 +221,7 @@ namespace kson
 		}
 	}
 
+	[[nodiscard]]
 	inline bool AlmostEquals(double a, double b)
 	{
 		return std::round(a * 1e8) == std::round(b * 1e8);

--- a/include/kson/Compat/CompatInfo.hpp
+++ b/include/kson/Compat/CompatInfo.hpp
@@ -15,6 +15,7 @@ namespace kson
 		std::string kshVersion;
 		KSHUnknownInfo kshUnknown;
 
+		[[nodiscard]]
 		bool isKSHVersionOlderThan(int kshVersionInt) const;
 	};
 }

--- a/include/kson/Encoding/Encoding.hpp
+++ b/include/kson/Encoding/Encoding.hpp
@@ -5,6 +5,7 @@ namespace kson
 {
 	namespace Encoding
 	{
+		[[nodiscard]]
 		std::string ShiftJISToUTF8(std::string_view shiftJISStr);
 	}
 }

--- a/include/kson/Error.hpp
+++ b/include/kson/Error.hpp
@@ -19,5 +19,6 @@ namespace kson
 		UnknownError = 90000,
 	};
 
+	[[nodiscard]]
 	const char *GetErrorString(ErrorType errorType);
 }

--- a/include/kson/Note/NoteInfo.hpp
+++ b/include/kson/Note/NoteInfo.hpp
@@ -13,6 +13,7 @@ namespace kson
 		std::int32_t w = kLaserXScale1x; // 1-2, sets whether the laser section is 2x-widen or not
 
 		// Returns 2x-widen or not
+		[[nodiscard]]
 		bool wide() const
 		{
 			return w == kLaserXScale2x;

--- a/include/kson/Util/GraphCurve.hpp
+++ b/include/kson/Util/GraphCurve.hpp
@@ -4,22 +4,26 @@
 namespace kson
 {
 	// Evaluates curve function with control points a, b at position x (all in range [0, 1])
+	[[nodiscard]]
 	double EvaluateCurve(double a, double b, double x);
 
 	// Evaluates the curve function using GraphCurveValue
 	// Returns x (linear) if curve.isLinear() is true
+	[[nodiscard]]
 	double EvaluateCurve(const GraphCurveValue& curve, double x);
 
 	// Expands a graph with curve data into linear segments at specified intervals
 	// Used for laser sections and scroll_speed where pre-conversion is required
 	// subdivisionInterval: interval in ticks for subdividing curve segments
 	// Returns a new graph with curve segments subdivided into linear segments
+	[[nodiscard]]
 	Graph ExpandCurveSegments(const Graph& graph, Pulse subdivisionInterval);
 
 	// Expands a graph section with curve data into linear segments at specified intervals
 	// Used for laser sections where pre-conversion is required
 	// subdivisionInterval: interval in ticks for subdividing curve segments
 	// Returns a new graph section with curve segments subdivided into linear segments
+	[[nodiscard]]
 	GraphSection ExpandCurveSegments(const GraphSection& graphSection, RelPulse subdivisionInterval);
 
 	// Forward declaration for LaserSection
@@ -28,5 +32,6 @@ namespace kson
 	// Expands a laser section with curve data into linear segments at specified intervals
 	// subdivisionInterval: interval in ticks for subdividing curve segments
 	// Returns a new laser section with curve segments subdivided into linear segments
+	[[nodiscard]]
 	LaserSection ExpandCurveSegments(const LaserSection& laserSection, RelPulse subdivisionInterval);
 }

--- a/include/kson/Util/GraphUtils.hpp
+++ b/include/kson/Util/GraphUtils.hpp
@@ -5,11 +5,14 @@
 
 namespace kson
 {
+	[[nodiscard]]
 	double GraphValueAt(const Graph& graph, Pulse pulse);
 
+	[[nodiscard]]
 	Graph BakeStopIntoScrollSpeed(const Graph& scrollSpeed, const ByPulse<RelPulse>& stop);
 
 	template <class GS>
+	[[nodiscard]]
 	typename ByPulse<GS>::const_iterator GraphSectionAt(const ByPulse<GS>& graphSections, Pulse pulse)
 #ifdef __cpp_concepts
 		requires std::is_same_v<GS, GraphSection> || std::is_same_v<GS, LaserSection>
@@ -27,6 +30,7 @@ namespace kson
 	}
 
 	template <class GS>
+	[[nodiscard]]
 	std::optional<double> GraphSectionValueAt(const ByPulse<GS>& graphSections, Pulse pulse)
 #ifdef __cpp_concepts
 		requires std::is_same_v<GS, GraphSection> || std::is_same_v<GS, LaserSection>
@@ -71,6 +75,7 @@ namespace kson
 	}
 
 	template <class GS>
+	[[nodiscard]]
 	double GraphSectionValueAtWithDefault(const ByPulse<GS>& graphSections, Pulse pulse, double defaultValue)
 #ifdef __cpp_concepts
 		requires std::is_same_v<GS, GraphSection> || std::is_same_v<GS, LaserSection>
@@ -88,6 +93,7 @@ namespace kson
 	}
 
 	template <class GS>
+	[[nodiscard]]
 	std::optional<GraphPoint> GraphPointAt(const ByPulse<GS>& graphSections, Pulse pulse)
 	{
 		if (graphSections.empty())

--- a/include/kson/Util/TiltUtils.hpp
+++ b/include/kson/Util/TiltUtils.hpp
@@ -6,11 +6,14 @@
 namespace kson
 {
 	// Get manual tilt value at the current pulse
+	[[nodiscard]]
 	std::optional<double> ManualTiltValueAt(const ByPulse<TiltValue>& tiltValue, Pulse currentPulse);
 
 	// Get auto tilt scale at the current pulse
+	[[nodiscard]]
 	double AutoTiltScaleAt(const ByPulse<TiltValue>& tiltValue, Pulse currentPulse);
 
 	// Get auto tilt keep enabled at the current pulse
+	[[nodiscard]]
 	bool AutoTiltKeepAt(const ByPulse<TiltValue>& tiltValue, Pulse currentPulse);
 }

--- a/include/kson/Util/TimingUtils.hpp
+++ b/include/kson/Util/TimingUtils.hpp
@@ -14,50 +14,78 @@ namespace kson
 		std::map<Pulse, std::int64_t> timeSigChangeMeasureIdx;
 	};
 
+	[[nodiscard]]
 	Pulse TimeSigOneMeasurePulse(const TimeSig& timeSig);
 
+	[[nodiscard]]
 	TimingCache CreateTimingCache(const BeatInfo& beatInfo);
 
+	[[nodiscard]]
 	double PulseToMs(Pulse pulse, const BeatInfo& beatInfo, const TimingCache& cache);
+	[[nodiscard]]
 	double PulseToSec(Pulse pulse, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	double PulseDoubleToMs(double pulse, const BeatInfo& beatInfo, const TimingCache& cache);
+	[[nodiscard]]
 	double PulseDoubleToSec(double pulse, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	Pulse MsToPulse(double ms, const BeatInfo& beatInfo, const TimingCache& cache);
+	[[nodiscard]]
 	Pulse SecToPulse(double sec, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	double MsToPulseDouble(double ms, const BeatInfo& beatInfo, const TimingCache& cache);
+	[[nodiscard]]
 	double SecToPulseDouble(double sec, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	std::int64_t PulseToMeasureIdx(Pulse pulse, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	std::int64_t MsToMeasureIdx(double ms, const BeatInfo& beatInfo, const TimingCache& cache);
+	[[nodiscard]]
 	std::int64_t SecToMeasureIdx(double sec, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	Pulse MeasureIdxToPulse(std::int64_t measureIdx, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	Pulse MeasureValueToPulse(double measureValue, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	double MeasureValueToPulseDouble(double measureValue, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	double MeasureIdxToMs(std::int64_t measureIdx, const BeatInfo& beatInfo, const TimingCache& cache);
+	[[nodiscard]]
 	double MeasureIdxToSec(std::int64_t measureIdx, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	double MeasureValueToMs(double measureValue, const BeatInfo& beatInfo, const TimingCache& cache);
+	[[nodiscard]]
 	double MeasureValueToSec(double measureValue, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	bool IsBarLinePulse(Pulse pulse, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	double TempoAt(Pulse pulse, const BeatInfo& beatInfo);
 
+	[[nodiscard]]
 	const TimeSig& TimeSigAt(Pulse pulse, const BeatInfo& beatInfo, const TimingCache& cache);
 
+	[[nodiscard]]
 	double GetModeBPM(const BeatInfo& beatInfo, Pulse lastPulse);
 
+	[[nodiscard]]
 	double GetEffectiveStdBPM(const ChartData& chartData);
 
+	[[nodiscard]]
 	kson::Pulse LastNoteEndY(const kson::NoteInfo& noteInfo);
+	[[nodiscard]]
 	kson::Pulse LastNoteEndYButtonLane(const kson::ByPulse<kson::Interval>& lane);
+	[[nodiscard]]
 	kson::Pulse LastNoteEndYLaserLane(const kson::ByPulse<kson::LaserSection>& lane);
 }


### PR DESCRIPTION
This pull request (following up from #8) applies the `[[nodiscard]]` attribute to appropriate functions (functions whose sole purpose are to return a value which ought not to be discarded).